### PR TITLE
fix: allow to define labels in namespace

### DIFF
--- a/charts/proxmox-csi-plugin/Chart.yaml
+++ b/charts/proxmox-csi-plugin/Chart.yaml
@@ -17,7 +17,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/proxmox-csi-plugin/templates/namespace.yaml
+++ b/charts/proxmox-csi-plugin/templates/namespace.yaml
@@ -7,4 +7,5 @@ metadata:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: baseline
     pod-security.kubernetes.io/warn: baseline
+    {{- include "proxmox-csi-plugin.labels" . | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)
Allow to define custom labels for namespace.
## Why? (reasoning)
Helm cant create namespace because the labels is hard code so that this PR should fix this problem as well as allow to define custom labels for namespace.

```
% helm template .
---
# Source: proxmox-csi-plugin/templates/namespace.yaml
apiVersion: v1
kind: Namespace
metadata:
  name: default
  labels:
    pod-security.kubernetes.io/enforce: privileged
    pod-security.kubernetes.io/audit: baseline
    pod-security.kubernetes.io/warn: baseline
    helm.sh/chart: proxmox-csi-plugin-0.2.0
    app.kubernetes.io/name: proxmox-csi-plugin
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v0.1.1"
    app.kubernetes.io/managed-by: Helm
```
## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
